### PR TITLE
Fix countdown timing on iOS by syncing steps with speech synthesis

### DIFF
--- a/js/voice.js
+++ b/js/voice.js
@@ -1,4 +1,5 @@
-export function speak(text) {
+// Optionally return the utterance object for event listening
+export function speak(text, returnUtterance = false) {
   if (!('speechSynthesis' in window)) return;
   const utter = new window.SpeechSynthesisUtterance(text);
   utter.rate = 0.85;
@@ -6,4 +7,5 @@ export function speak(text) {
   utter.lang = 'en-US';
   window.speechSynthesis.cancel(); // Stop any previous utterances
   window.speechSynthesis.speak(utter);
+  if (returnUtterance) return utter;
 }


### PR DESCRIPTION
- Use a speakAndWait helper to wait for speechSynthesis utterance to
  finish before proceeding to the next countdown step.
- Ensures even spacing between "Starting in 3", "2", and "1" on all
  platforms, including iOS where speechSynthesis and setTimeout can
  get out of sync.
- Update speak() in voice.js to optionally return the utterance object
  for
